### PR TITLE
Upgrade to Kotlin 1.2.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.2'
+  ext.kotlin_version = '1.2.10'
   ext.kotlin_xml_dsl_version = '0.1.6'
 
   repositories { mavenCentral() }

--- a/jdom/src/main/kotlin/org/jonnyzzz/kotlin/xml/bind/jdom/impl/XProperties.kt
+++ b/jdom/src/main/kotlin/org/jonnyzzz/kotlin/xml/bind/jdom/impl/XProperties.kt
@@ -1,6 +1,6 @@
 package org.jonnyzzz.kotlin.xml.bind.jdom.impl
 
-import kotlin.reflect.declaredMemberProperties
+import kotlin.reflect.full.declaredMemberProperties
 
 
 internal fun <T : Any> Class<T>.declaredPropertyNames(): Set<String> {


### PR DESCRIPTION
The current version (1.0.2) uses the now removed `kotlin.reflect.declaredMemberProperties` instead of the new `kotlin.reflect.full.declaredMemberProperties`. When working with newer Kotlin versions this prevents the use of the newest Kotlin reflection library (1.2.10) since it causes a runtime error.

Below you can see the error:
```
Exception in thread "main" java.lang.NoClassDefFoundError: kotlin/reflect/KClasses
        at org.jonnyzzz.kotlin.xml.bind.jdom.impl.XPropertiesKt.declaredPropertyNames(XProperties.kt:7)
        at org.jonnyzzz.kotlin.xml.bind.jdom.impl.XPropertiesKt.scan(XProperties.kt:13)
        at org.jonnyzzz.kotlin.xml.bind.jdom.impl.XPropertiesKt.scan$default(XProperties.kt:12)
        at org.jonnyzzz.kotlin.xml.bind.jdom.impl.XPropertiesKt.delegatedProperties(XProperties.kt:10)
        at org.jonnyzzz.kotlin.xml.bind.jdom.impl.JDOMIMPL.elementsToBind(XBind.impl.kt:38)
        at org.jonnyzzz.kotlin.xml.bind.jdom.impl.JDOMIMPL.bind(XBind.impl.kt:45)
        at org.jonnyzzz.kotlin.xml.bind.jdom.impl.JDOMIMPL.load(XBind.impl.kt:40)
        at org.jonnyzzz.kotlin.xml.bind.jdom.JDOM.load(XBind.jdom.kt:24)
        at [some code]
Caused by: java.lang.ClassNotFoundException: kotlin.reflect.KClasses
        at java.net.URLClassLoader.findClass(Unknown Source)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        at sun.misc.Launcher$AppClassLoader.loadClass(Unknown Source)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        ... 9 more
```